### PR TITLE
Fixes package.json main to the good path so it just works

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "url": "git://github.com/davglass/node-getrusage.git"
     }
   ],
-  "main": "./getrusage",
+  "main": "./build/default/getrusage",
   "scripts": {
     "build": "node-waf configure build",
     "test": "node-waf test",


### PR DESCRIPTION
Version 0.2.0 refers in package.json to ./getrusage which does not exist, this file is in build/default/getrusage

Without this fix, the librarie is not usable like a regular package :(
